### PR TITLE
allow to create view cache with artisan

### DIFF
--- a/src/Providers/BlogServiceProvider.php
+++ b/src/Providers/BlogServiceProvider.php
@@ -58,7 +58,6 @@ class BlogServiceProvider extends ServiceProvider
     {
         // Load views
         $this->loadViewsFrom(self::PACKAGE_DIR . 'resources/views', 'voyager-blog');
-        $this->loadViewsFrom(self::PACKAGE_DIR . 'resources/views/vendor/voyager', 'voyager');
     }
 
     /**


### PR DESCRIPTION
there is no vendor directory under resources/views, because of that, view cache cannot be generated.