### PR TITLE
Make Meta Keywords Nullable

### DIFF
--- a/database/migrations/2018_04_18_000000_create_blog_posts_table.php
+++ b/database/migrations/2018_04_18_000000_create_blog_posts_table.php
@@ -25,7 +25,7 @@ class CreateBlogPostsTable extends Migration
                 $table->string('image')->nullable();
                 $table->string('slug')->unique();
                 $table->text('meta_description');
-                $table->text('meta_keywords');
+                $table->text('meta_keywords')->nullable();
                 $table->enum('status', ['PUBLISHED', 'DRAFT', 'PENDING'])->default('DRAFT');
                 $table->boolean('featured')->default(0);
                 $table->timestamps();


### PR DESCRIPTION
Make the `meta_keywords` column `nullable` as there is no corresponding seed in `database/seeds/BlogTableSeeder.php`